### PR TITLE
Updating init and run hooks to match bug fixes made in tutorial docs

### DIFF
--- a/mytutorialapp/hooks/init
+++ b/mytutorialapp/hooks/init
@@ -1,5 +1,5 @@
 #!/bin/sh
 #
-ln -s {{pkg.path}}/package.json {{pkg.svc_path}}
-ln -s {{pkg.path}}/server.js {{pkg.svc_path}}
-ln -s {{pkg.path}}/node_modules {{pkg.svc_path}}
+ln -sf {{pkg.path}}/package.json {{pkg.svc_path}}
+ln -sf {{pkg.path}}/server.js {{pkg.svc_path}}
+ln -sf {{pkg.path}}/node_modules {{pkg.svc_path}}

--- a/mytutorialapp/hooks/run
+++ b/mytutorialapp/hooks/run
@@ -1,4 +1,9 @@
 #!/bin/sh
 #
 cd {{pkg.svc_path}}
-npm start
+
+# `exec` makes it so the process that the Habitat supervisor uses is
+# `npm start`, rather than the run hook itself. `2>&1` makes it so both
+# standard output and standard error go to the standard output stream,
+# so all the logs from the application go to the same place.
+exec npm start 2>&1 


### PR DESCRIPTION
- Updated init hook to force symlinks to package source files. Without forcing the symlinks, the service would crash on restart.

- Updated run hook so that the supervisor uses the npm binary directly, instead of going through the run hook bash script.

These changes match the code blocks in the Getting Started tutorial.

Signed-off-by: David Wrede <dwrede@chef.io>