### PR TITLE
using npm start results in multiple child processes upon reconfigure

### DIFF
--- a/mytutorialapp_finished/habitat/hooks/run
+++ b/mytutorialapp_finished/habitat/hooks/run
@@ -3,7 +3,7 @@
 cd {{pkg.svc_var_path}}
 
 # `exec` makes it so the process that the Habitat supervisor uses is
-# `npm start`, rather than the run hook itself. `2>&1` makes it so both
+# `node server.js`, rather than the run hook itself. `2>&1` makes it so both
 # standard output and standard error go to the standard output stream,
 # so all the logs from the application go to the same place.
-exec npm start 2>&1 
+exec node server.js 2>&1


### PR DESCRIPTION
Solution:
change `npm start` to `node server.js`, this skips the additional
process that `npm start` creates

Signed-off-by: Dave Parfitt <dparfitt@chef.io>
see: https://github.com/habitat-sh/habitat/issues/1340