### PR TITLE
Switch from core to habitat origins for the postgresql image

### DIFF
--- a/myrailsapp/docker-compose.yml
+++ b/myrailsapp/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '3'
 services:
    db:
-     image: core/postgresql
-     volumes:       
+     image: habitat/postgresql
+     volumes:
        - "./updated_config.toml:/updated_config.toml"
    railsapp:
       image: originname/myrailsapp
       ports:
         - 8000:8000
-      links: 
+      links:
        - db
-      command: --peer db --bind database:postgresql.default 
+      command: --peer db --bind database:postgresql.default


### PR DESCRIPTION
https://www.habitat.sh/tutorials/sample-app/mac/run-app/ shows ```habitat/postgresql``` but the code still says ```core/postgresql```

Signed-off-by: Matt Ray <matthewhray@gmail.com>